### PR TITLE
Bump refile version and fix preview data issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
+### 0.9.2 - 2015-02-05
+Features
+  - Refile version 0.5.3
+
 ### 0.9.1 - 2015-01-12
 Features
   - Godmin version 0.9.7
-  - Refile version 0.4.2
+  - Refile version 0.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ Features
 ### 0.9.1 - 2015-01-12
 Features
   - Godmin version 0.9.7
-  - Refile version 0.5.3
+  - Refile version 0.4.2

--- a/app/assets/javascripts/godmin-uploads/index.js
+++ b/app/assets/javascripts/godmin-uploads/index.js
@@ -73,7 +73,7 @@
     var $urlParts = getFileUrlParts($el);
 
     $el.find(".godmin-upload-preview").attr(
-      "src", $urlParts[0] + "/fill/150/150/" + $urlParts[1] + "/foobar"
+      "src", $urlParts[0] + "/fill/150/150/" + $urlParts[1].id + "/foobar"
     );
   };
 
@@ -81,7 +81,7 @@
     var $urlParts = getFileUrlParts($el);
 
     $el.find(".godmin-upload-download-link").attr(
-      "href", $urlParts[0] + "/" + $urlParts[1] + "/foobar"
+      "href", $urlParts[0] + "/" + $urlParts[1].id + "/foobar"
     );
   };
 
@@ -89,7 +89,7 @@
     var $file = $el.find(".godmin-upload-file-field");
 
     return [
-      $file.data("url"), $file.prev().val()
+      $file.data("url"), JSON.parse($file.prev().val())
     ];
   };
 

--- a/godmin-uploads.gemspec
+++ b/godmin-uploads.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "godmin", "~> 0.9.7"
-  gem.add_dependency "refile", "~> 0.4.2"
+  gem.add_dependency "refile", "~> 0.5.3"
   gem.add_dependency "mini_magick", "~> 4.0.1"
 
   gem.add_development_dependency "bundler", "~> 1.7"

--- a/lib/godmin/uploads/version.rb
+++ b/lib/godmin/uploads/version.rb
@@ -1,5 +1,5 @@
 module Godmin
   module Uploads
-    VERSION = "0.9.1"
+    VERSION = "0.9.2"
   end
 end


### PR DESCRIPTION
Refile seems to have changed the value of a field which threw the preview for a loop. It now returns a JSON value which has to be parsed.